### PR TITLE
Change Scope of bukkit dependency to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
             <version>1.13.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Change the Scope of the Bukkit Dependency to provided, so maven doesn't complain about overlapping classes that are present in json-simple.